### PR TITLE
Update to Laravel 5.8

### DIFF
--- a/src/LaraInvite.php
+++ b/src/LaraInvite.php
@@ -264,7 +264,7 @@ class LaraInvite implements InvitationInterface
      */
     private function publishEvent($event)
     {
-        Event::fire('junaidnasir.larainvite.'.$event, $this->instance, false);
+        Event::dispatch('junaidnasir.larainvite.'.$event, $this->instance, false);
         return $this;
     }
 }


### PR DESCRIPTION
`fire` method was removed in the 5.8 version of Laravel. See: https://laravel.com/docs/5.8/upgrade#upgrade-5.8.0 (Events section). After the guide:

> The `fire` method (which was deprecated in Laravel 5.4) of the `Illuminate/Events/Dispatcher` class has been removed. You should use the `dispatch` method instead.