### PR TITLE
Support Laravel 5.8

### DIFF
--- a/src/LaraInvite.php
+++ b/src/LaraInvite.php
@@ -179,7 +179,7 @@ class LaraInvite implements InvitationInterface
      */
     public function reminder()
     {
-        Event::fire('junaidnasir.larainvite.invited', $this->instance, false);
+        Event::dispatch('junaidnasir.larainvite.invited', $this->instance, false);
         return true;
     }
 


### PR DESCRIPTION
Event::fire is removed in 5.8. Replacing it with Event::dispatch